### PR TITLE
Add github action for building and running tests.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,38 @@
+name: build and test
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+    paths:
+    - '**.cs'
+    - '**.csproj'
+
+env:
+  DOTNET_VERSION: '7.0.102' # The .NET SDK version to use
+  SNL_PATH: 'src/MicroservicesSimulationFramework/MicroservicesSimulationFramework.sln'
+
+jobs:
+  build-and-test:
+
+    name: build-and-test-${{matrix.os}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Install dependencies
+      run: dotnet restore ${{ env.SNL_PATH }}
+      
+    - name: Build
+      run: dotnet build --configuration Release ${{ env.SNL_PATH }}
+    
+    - name: Test
+      run: dotnet test --no-restore --verbosity normal ${{ env.SNL_PATH }}

--- a/src/WorkloadGenerator/WorkloadGenerator.Data/WorkloadGenerator.Data.csproj
+++ b/src/WorkloadGenerator/WorkloadGenerator.Data/WorkloadGenerator.Data.csproj
@@ -17,6 +17,7 @@
 
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.18.0" />
+        <PackageReference Include="FluentValidation" Version="11.5.1" />
         <PackageReference Include="JsonDocumentPath" Version="1.0.3" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     </ItemGroup>


### PR DESCRIPTION
The WorkloadGenerator.Data.csproj file had a weird local reference to the FluentValidation package, I had to fix it by adding a package reference, we might look into cleaning this up in all places in the project.